### PR TITLE
Fix: compatibilità con Python 3.12 (fork yapsy patchato)

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,4 +5,4 @@ marshmallow==3.18.0
 marshmallow-dataclass==8.5.9
 Pebble==4.5.3
 pytest-cov==4.1.0
-Yapsy==1.12.2
+yapsy @ git+https://github.com/talos-security/yapsy.git@master


### PR DESCRIPTION
La libreria "yapsy" utilizzata da SEBASTiAn non è più mantenuta e risulta incompatibile con Python 3.12+ a causa dell'uso del modulo deprecato "imp".

In seguito ad una segnalazione interna ho creato un fork di yapsy al seguente:  
https://github.com/talos-security/yapsy

In questa PR viene aggiornato il file "requirements.txt" per installare "yapsy" dal fork, consentendo l’esecuzione di SEBASTiAn anche su Python 3.12 o superiore.

Testato localmente con:
- Python 3.12
- CLI funzionante (`python -m cli --help`)

